### PR TITLE
RDM verproc cancel prevention and optional 84~94 optimization

### DIFF
--- a/XIVComboExpanded/Combos/RDM.cs
+++ b/XIVComboExpanded/Combos/RDM.cs
@@ -281,7 +281,7 @@ namespace XIVComboExpandedestPlugin.Combos
                         if (IsEnabled(CustomComboPreset.RedMageVerprocCancelPrevention))
                         {
                             var verstoneEffect = FindEffect(RDM.Buffs.VerstoneReady);
-                            if (verstoneEffect != null && verstoneEffect.RemainingTime > 2)
+                            if (verstoneEffect != null && verstoneEffect.RemainingTime > Service.Configuration.VerprocCancelThreshold)
                                 return RDM.Verstone;
                         }
                         else
@@ -298,7 +298,7 @@ namespace XIVComboExpandedestPlugin.Combos
                         if (IsEnabled(CustomComboPreset.RedMageVerprocCancelPrevention))
                         {
                             var verfireEffect = FindEffect(RDM.Buffs.VerfireReady);
-                            if (verfireEffect != null && verfireEffect.RemainingTime > 2)
+                            if (verfireEffect != null && verfireEffect.RemainingTime > Service.Configuration.VerprocCancelThreshold)
                                 return RDM.Verfire;
                         }
                         else

--- a/XIVComboExpanded/Combos/RDM.cs
+++ b/XIVComboExpanded/Combos/RDM.cs
@@ -283,6 +283,9 @@ namespace XIVComboExpandedestPlugin.Combos
                             var verstoneEffect = FindEffect(RDM.Buffs.VerstoneReady);
                             if (verstoneEffect == null || verstoneEffect.RemainingTime < 0f || verstoneEffect.RemainingTime > Service.Configuration.VerprocCancelThreshold)
                                 return RDM.Verstone;
+                            if (!HasCondition(ConditionFlag.InCombat) && IsEnabled(CustomComboPreset.RedMageVerprocOpenerFeatureStone) &&
+                                level >= RDM.Levels.Veraero)
+                                return OriginalHook(RDM.Veraero);
                         }
                         else
                         {
@@ -300,6 +303,9 @@ namespace XIVComboExpandedestPlugin.Combos
                             var verfireEffect = FindEffect(RDM.Buffs.VerfireReady);
                             if (verfireEffect == null || verfireEffect.RemainingTime < 0f || verfireEffect.RemainingTime > Service.Configuration.VerprocCancelThreshold)
                                 return RDM.Verfire;
+                            if (!HasCondition(ConditionFlag.InCombat) && IsEnabled(CustomComboPreset.RedMageVerprocOpenerFeatureFire) &&
+                                level >= RDM.Levels.Verthunder)
+                                return OriginalHook(RDM.Verthunder);
                         }
                         else
                         {

--- a/XIVComboExpanded/Combos/RDM.cs
+++ b/XIVComboExpanded/Combos/RDM.cs
@@ -272,17 +272,45 @@ namespace XIVComboExpandedestPlugin.Combos
                         if (level >= RDM.Levels.Jolt3 && level < RDM.Levels.VerprocBuff)
                             return OriginalHook(RDM.Jolt2);
                     }
+
+                    if (actionID == RDM.Verstone && HasEffect(RDM.Buffs.VerstoneReady))
+                    {
+                        if (IsEnabled(CustomComboPreset.RedMageVerprocComboVerstoneOption))
+                            return RDM.Verstone;
+
+                        if (IsEnabled(CustomComboPreset.RedMageVerprocCancelPrevention))
+                        {
+                            var verstoneEffect = FindEffect(RDM.Buffs.VerstoneReady);
+                            if (verstoneEffect != null && verstoneEffect.RemainingTime > 2)
+                                return RDM.Verstone;
+                        }
+                        else
+                        {
+                            return RDM.Verstone;
+                        }
+                    }
+
+                    if (blackMagic && HasEffect(RDM.Buffs.VerfireReady))
+                    {
+                        if (IsEnabled(CustomComboPreset.RedMageVerprocComboVerfireOption))
+                            return RDM.Verfire;
+
+                        if (IsEnabled(CustomComboPreset.RedMageVerprocCancelPrevention))
+                        {
+                            var verfireEffect = FindEffect(RDM.Buffs.VerfireReady);
+                            if (verfireEffect != null && verfireEffect.RemainingTime > 2)
+                                return RDM.Verfire;
+                        }
+                        else
+                        {
+                            return RDM.Verfire;
+                        }
+                    }
                 }
 
-                if (actionID == RDM.Verstone && HasEffect(RDM.Buffs.VerstoneReady))
-                    return RDM.Verstone;
-
-                if (blackMagic && HasEffect(RDM.Buffs.VerfireReady))
-                    return RDM.Verfire;
-
                 if ((blackMagic && !IsEnabled(CustomComboPreset.RedMageVerprocComboVerfireOption)) || (actionID == RDM.Verstone && !IsEnabled(CustomComboPreset.RedMageVerprocComboVerstoneOption)))
-                    return OriginalHook(RDM.Jolt2);
-            }
+                        return OriginalHook(RDM.Jolt2);
+                }
 
             return actionID;
         }

--- a/XIVComboExpanded/Combos/RDM.cs
+++ b/XIVComboExpanded/Combos/RDM.cs
@@ -281,7 +281,7 @@ namespace XIVComboExpandedestPlugin.Combos
                         if (IsEnabled(CustomComboPreset.RedMageVerprocCancelPrevention))
                         {
                             var verstoneEffect = FindEffect(RDM.Buffs.VerstoneReady);
-                            if (verstoneEffect != null && verstoneEffect.RemainingTime > Service.Configuration.VerprocCancelThreshold)
+                            if (verstoneEffect == null || verstoneEffect.RemainingTime < 0f || verstoneEffect.RemainingTime > Service.Configuration.VerprocCancelThreshold)
                                 return RDM.Verstone;
                         }
                         else
@@ -298,7 +298,7 @@ namespace XIVComboExpandedestPlugin.Combos
                         if (IsEnabled(CustomComboPreset.RedMageVerprocCancelPrevention))
                         {
                             var verfireEffect = FindEffect(RDM.Buffs.VerfireReady);
-                            if (verfireEffect != null && verfireEffect.RemainingTime > Service.Configuration.VerprocCancelThreshold)
+                            if (verfireEffect == null || verfireEffect.RemainingTime < 0f || verfireEffect.RemainingTime > Service.Configuration.VerprocCancelThreshold)
                                 return RDM.Verfire;
                         }
                         else

--- a/XIVComboExpanded/Combos/RDM.cs
+++ b/XIVComboExpanded/Combos/RDM.cs
@@ -283,8 +283,7 @@ namespace XIVComboExpandedestPlugin.Combos
                             var verstoneEffect = FindEffect(RDM.Buffs.VerstoneReady);
                             if (verstoneEffect == null || verstoneEffect.RemainingTime < 0f || verstoneEffect.RemainingTime > Service.Configuration.VerprocCancelThreshold)
                                 return RDM.Verstone;
-                            if (!HasCondition(ConditionFlag.InCombat) && IsEnabled(CustomComboPreset.RedMageVerprocOpenerFeatureStone) &&
-                                level >= RDM.Levels.Veraero)
+                            if (!HasCondition(ConditionFlag.InCombat) && IsEnabled(CustomComboPreset.RedMageVerprocOpenerFeatureStone) && level >= RDM.Levels.Veraero)
                                 return OriginalHook(RDM.Veraero);
                         }
                         else
@@ -303,8 +302,7 @@ namespace XIVComboExpandedestPlugin.Combos
                             var verfireEffect = FindEffect(RDM.Buffs.VerfireReady);
                             if (verfireEffect == null || verfireEffect.RemainingTime < 0f || verfireEffect.RemainingTime > Service.Configuration.VerprocCancelThreshold)
                                 return RDM.Verfire;
-                            if (!HasCondition(ConditionFlag.InCombat) && IsEnabled(CustomComboPreset.RedMageVerprocOpenerFeatureFire) &&
-                                level >= RDM.Levels.Verthunder)
+                            if (!HasCondition(ConditionFlag.InCombat) && IsEnabled(CustomComboPreset.RedMageVerprocOpenerFeatureFire) && level >= RDM.Levels.Verthunder)
                                 return OriginalHook(RDM.Verthunder);
                         }
                         else

--- a/XIVComboExpanded/Combos/RDM.cs
+++ b/XIVComboExpanded/Combos/RDM.cs
@@ -266,8 +266,13 @@ namespace XIVComboExpandedestPlugin.Combos
                     return OriginalHook(RDM.Reprise);
 
                 if ((blackMagic && !IsEnabled(CustomComboPreset.RedMageVerprocComboVerfireOption)) || (actionID == RDM.Verstone && !IsEnabled(CustomComboPreset.RedMageVerprocComboVerstoneOption)))
-                    if (level >= RDM.Levels.Jolt3 && level < RDM.Levels.VerprocBuff)
-                        return OriginalHook(RDM.Jolt2);
+                {
+                    if (IsEnabled(CustomComboPreset.RedMageVerprocJolt3Option))
+                    {
+                        if (level >= RDM.Levels.Jolt3 && level < RDM.Levels.VerprocBuff)
+                            return OriginalHook(RDM.Jolt2);
+                    }
+                }
 
                 if (actionID == RDM.Verstone && HasEffect(RDM.Buffs.VerstoneReady))
                     return RDM.Verstone;

--- a/XIVComboExpanded/ConfigWindow.cs
+++ b/XIVComboExpanded/ConfigWindow.cs
@@ -254,7 +254,7 @@ namespace XIVComboExpandedestPlugin
 
                             ImGui.Indent();
                             var inputChanged = false;
-                            inputChanged |= ImGui.SliderFloat("Proc Cancel Threshold (seconds)", ref cancelThreshold, 1.90f, 2.50f, "%.2f");
+                            inputChanged |= ImGui.SliderFloat("Proc Cancel Threshold (seconds)", ref cancelThreshold, 1.90f, 3.00f, "%.2f");
                             ImGui.Unindent();
 
                             if (inputChanged)

--- a/XIVComboExpanded/ConfigWindow.cs
+++ b/XIVComboExpanded/ConfigWindow.cs
@@ -248,6 +248,24 @@ namespace XIVComboExpandedestPlugin
                             ImGui.Spacing();
                         }
 
+                        if (preset == CustomComboPreset.RedMageVerprocCancelPrevention && enabled)
+                        {
+                            float cancelThreshold = Service.Configuration.VerprocCancelThreshold;
+
+                            ImGui.Indent();
+                            var inputChanged = false;
+                            inputChanged |= ImGui.SliderFloat("Proc Cancel Threshold (seconds)", ref cancelThreshold, 1.90f, 2.50f, "%.2f");
+                            ImGui.Unindent();
+
+                            if (inputChanged)
+                            {
+                                Service.Configuration.VerprocCancelThreshold = cancelThreshold;
+                                Service.Configuration.Save();
+                            }
+
+                            ImGui.Spacing();
+                        }
+
                         if (parent != null)
                             ImGui.Unindent();
 

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -1216,6 +1216,13 @@ namespace XIVComboExpandedestPlugin
         [CustomComboInfo("Verproc into Jolt Plus Verthunder Option", "Verthunder is used as the base for the black magic side of Verproc into Jolt, not Verfire.\nThis is so you can use Verfire by itself even with acceleration up to use a slightly more optimal opener.", RDM.JobID, RDM.Verthunder)]
         RedMageVerprocComboVerthunderOption = 3526,
 
+
+        [OrderedEnum]
+        [ParentCombo(RedMageVerprocCombo)]
+        [CustomComboInfo("Verproc to Jolt 3 Optimization", "Changes Verstone/Verfire to Jolt 3 when it is a DPS gain.", RDM.JobID, RDM.Verstone, RDM.Verfire)]
+        RedMageVerprocJolt3Option = 3527,
+
+
         [OrderedEnum]
         [ParentCombo(RedMageVerprocComboPlus)]
         [CustomComboInfo("Verproc into Jolt Plus Option", "Verstone/Verfire never get replaced by their respective long cast (Veraero/Verthunder) if usable (unless both are usable).\nMildly incompatible with current RDM opener.", RDM.JobID, RDM.Verstone, RDM.Verfire)]

--- a/XIVComboExpanded/CustomComboPreset.cs
+++ b/XIVComboExpanded/CustomComboPreset.cs
@@ -1216,12 +1216,15 @@ namespace XIVComboExpandedestPlugin
         [CustomComboInfo("Verproc into Jolt Plus Verthunder Option", "Verthunder is used as the base for the black magic side of Verproc into Jolt, not Verfire.\nThis is so you can use Verfire by itself even with acceleration up to use a slightly more optimal opener.", RDM.JobID, RDM.Verthunder)]
         RedMageVerprocComboVerthunderOption = 3526,
 
-
         [OrderedEnum]
         [ParentCombo(RedMageVerprocCombo)]
         [CustomComboInfo("Verproc to Jolt 3 Optimization", "Changes Verstone/Verfire to Jolt 3 when it is a DPS gain.", RDM.JobID, RDM.Verstone, RDM.Verfire)]
         RedMageVerprocJolt3Option = 3527,
 
+        [OrderedEnum]
+        [ParentCombo(RedMageVerprocCombo)]
+        [CustomComboInfo("Verproc Cancel Prevention", "Changes Verstone/Verfire to Jolt when their buff has 2 seconds or less remaining to prevent canceling the cast.", RDM.JobID, RDM.Verstone, RDM.Verfire)]
+        RedMageVerprocCancelPrevention = 3528,
 
         [OrderedEnum]
         [ParentCombo(RedMageVerprocComboPlus)]

--- a/XIVComboExpanded/PluginConfiguration.cs
+++ b/XIVComboExpanded/PluginConfiguration.cs
@@ -77,6 +77,11 @@ namespace XIVComboExpandedestPlugin
         public double LucidCooldownOffset { get; set; } = 0;
 
         /// <summary>
+        /// Gets or sets the threshold for Verproc Cancel Prevention. Default is 2.0.
+        /// </summary>
+        public float VerprocCancelThreshold { get; set; } = 2.0f;
+
+        /// <summary>
         /// Save the configuration to disk.
         /// </summary>
         public void Save()


### PR DESCRIPTION
Makes the lvl 84~94 optimization (verproc into jolt) optional
Adds logic to change verproc into back into jolt if there is 2 seconds or less of "Verproc Ready" buff